### PR TITLE
Add preload_app and on_worker_boot settings

### DIFF
--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -3,7 +3,8 @@ define :puma_config, owner: nil, group: nil, directory: nil, puma_directory: nil
                      stdout_redirect: nil, stderr_redirect: nil, output_append: false,
                      quiet: false, thread_min: 0, thread_max: 16, bind: nil, control_app_bind: nil,
                      workers: 0, activate_control_app: true, monit: true, logrotate: true, exec_prefix: nil,
-                     monit_timeout: 10, config_source: nil, config_cookbook: nil, init_file: nil do
+                     monit_timeout: 10, config_source: nil, config_cookbook: nil, init_file: nil,
+                     preload_app: false, on_worker_boot: nil do
 
 
   # Set defaults if not supplied by caller.

--- a/templates/default/puma.rb.erb
+++ b/templates/default/puma.rb.erb
@@ -20,6 +20,9 @@ directory "<%= @working_dir %>"
 rackup "<%= @rackup %>"
 <% end %>
 
+<% if @preload_app %>
+  preload_app!
+<% end %>
 
 # Set the environment in which the rack's app will run. The value must be a string.
 # The default is "development".
@@ -102,6 +105,11 @@ workers <%= @workers %>
 # on_worker_boot do
 #   puts 'On worker boot...'
 # end
+<% if @on_worker_boot %>
+on_worker_boot do
+  <%= @on_worker_boot %>
+end
+<% end %>
 
 # === Puma control rack application ===
 


### PR DESCRIPTION
When running in cluster mode, it may be useful to configure preload_app. Also, adding on_worker_boot option for those who may want to use it for `ActiveRecord::Base.establish_connection`.

This options conflicts with phased restart, so false by default.
