### PR TITLE
Upstart init conf should match file permissions

### DIFF
--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -136,7 +136,7 @@ define :puma_config, owner: nil, group: nil, directory: nil, puma_directory: nil
       group "root"
       cookbook "puma"
       source "upstart.erb"
-      mode "0755"
+      mode "0644"
       variables puma_params
     end
 


### PR DESCRIPTION
The file permission 755 was not matched to what upstart requires. 644 is expected.
