### PR TITLE
use rubygems_location for puma gem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,4 +13,5 @@ end
 gem_package 'puma' do
   action :install
   version node.puma[:version]
+  gem_binary node.puma[:rubygems_location]  
 end


### PR DESCRIPTION
when defining the puma gem, the gem binary was not being specified making it impossible to use it with rbenv.
