### PR TITLE
Respect `logrotate false` param to `puma_config`

### DIFF
--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -160,7 +160,7 @@ define :puma_config, owner: nil, group: nil, directory: nil, puma_directory: nil
     size "5M"
     options ["missingok", "compress", "delaycompress", "notifempty", "dateext"]
     variables puma_params
-    only_if params[:logrotate]
+    enable params[:logrotate]
   end
 
 end


### PR DESCRIPTION
I was puzzled when I saw new configs under `/etc/logrotate.d` even with `logrotate false`. It turns out the `logrotate_app` definition never supported `only_if` (https://github.com/stevendanna/logrotate/issues/66), but _does_ offer an `enable` param with similar functionality.

Fixes #16.
