### PR TITLE
Add support for prune_bundler config flag

### DIFF
--- a/definitions/puma_config.rb
+++ b/definitions/puma_config.rb
@@ -4,7 +4,7 @@ define :puma_config, owner: nil, group: nil, directory: nil, puma_directory: nil
                      quiet: false, thread_min: 0, thread_max: 16, bind: nil, control_app_bind: nil,
                      workers: 0, activate_control_app: true, monit: true, logrotate: true, exec_prefix: nil,
                      monit_timeout: 10, config_source: nil, config_cookbook: nil, init_file: nil,
-                     preload_app: false, on_worker_boot: nil, upstart: false do
+                     preload_app: false, on_worker_boot: nil, upstart: false, prune_bundler: false do
 
 
   # Set defaults if not supplied by caller.

--- a/templates/default/puma.rb.erb
+++ b/templates/default/puma.rb.erb
@@ -113,6 +113,15 @@ on_worker_boot do
 end
 <% end %>
 
+# Allow workers to reload bundler context when master process is issued
+# a USR1 signal. This allows proper reloading of gems while the master
+# is preserved across a phased-restart. (incompatible with preload_app)
+# (off by default)
+<% if @prune_bundler %>
+prune_bundler
+<% end %>
+
+
 # === Puma control rack application ===
 
 # Start the puma control rack application on "url". This application can


### PR DESCRIPTION
This adds support for the `prune_bundler` flag, which is necessary when using phased restarts.

https://github.com/puma/puma/blob/4ca81231c42828980dad26cfe21e47ba527d8be9/examples/config.rb#L138-L143
