### PR TITLE
Add phased restart to monit

### DIFF
--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -5,3 +5,4 @@ check process <%= @name %>.puma with pidfile <%= @pidfile %>
       <% else %>
       stop program = "/bin/su - <%= @owner %> -c 'cd <%= @working_dir %> && <%= @exec_prefix %> pumactl -S <%= @state_path %> stop'"
       <% end %>
+      restart program = "/bin/su - -c '<%= "#{@puma_directory}/puma_phased_restart.sh" %>'"


### PR DESCRIPTION
With newer versions of `monit` you can use `restart program`... this simply updates the monit config to run the existing puma phased restart script for when puma is in `clustered` mode (> 2 workers).

I've separately built Monit 5.19 for Ubuntu 14.04.5 (https://s3-ap-southeast-2.amazonaws.com/activepipe-devops/monit_5.19.0-1_amd64.deb) but more recent versions should be available on Ubuntu 16.04.1 (https://launchpad.net/ubuntu/xenial/amd64/monit/1:5.14-2).

Cheers,
Nigel (@wtfiwtz)
