### PR TITLE
Fix invalid option: --no-ri

### DIFF
--- a/definitions/puma_install.rb
+++ b/definitions/puma_install.rb
@@ -1,9 +1,8 @@
 define :puma_install, gem_bin_path: "/usr/local/bin/gem" do
-                                         
+
   gem_package 'bundler' do
     version node["puma"]["bundler_version"]
     gem_binary params[:gem_bin_path]
-    options '--no-ri --no-rdoc'
   end
 
   gem_package 'puma' do


### PR DESCRIPTION
Remove the now invalid `--no-ri` and `--no-rdoc` options. They've been replaced by `--no-document` but for better compatibility, I think it's best to have none of these options set at all, as the defaults should work just fine.

See https://github.com/rubygems/rubygems/pull/2354